### PR TITLE
Update schema.js

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -140,7 +140,7 @@ Schema.prototype.validate = function (obj, opts) {
 
   for (var key in this.props) {
     var prop = this.props[key];
-    var value = dot.get(obj, key);
+    var value = key ? dot.get(obj, key) : obj;
     var err = prop.validate(value, obj);
     if (err) errors.push(err);
   }


### PR DESCRIPTION
Make schema.path("").use(obj => {xxxxxx}) useful for validate the whole obj if the paths are related.

for example {a: 12, b: 5}, in schema a is required to be greater than b, then we should use syntax like the above...
